### PR TITLE
SLO-SLC Roles

### DIFF
--- a/event_manager/mutations.py
+++ b/event_manager/mutations.py
@@ -134,15 +134,16 @@ class ProgressEvent(graphene.Mutation):
                     event_instance.state = EVENT_STATE_DICT["fc_pending"]
                 # else progress to SLO
                 else:
-                    event_instance.state = EVENT_STATE_DICT["slo_pending"]
+                    event_instance.state = EVENT_STATE_DICT["slc_pending"]
 
             elif event_instance.state == EVENT_STATE_DICT["fc_pending"]:
                 # progress to SLO
-                event_instance.state = EVENT_STATE_DICT["slo_pending"]
-
-            elif event_instance.state == EVENT_STATE_DICT["slo_pending"]:
-                # progress to SLC
+                # progressing directly to SLC Pending Event
                 event_instance.state = EVENT_STATE_DICT["slc_pending"]
+
+            # elif event_instance.state == EVENT_STATE_DICT["slo_pending"]:
+            #     # progress to SLC
+            #     event_instance.state = EVENT_STATE_DICT["slc_pending"]
 
             elif event_instance.state == EVENT_STATE_DICT["slc_pending"]:
                 # check if room requirement is listed, if yes progress to GAD

--- a/scripts/db_setup.py
+++ b/scripts/db_setup.py
@@ -11,10 +11,11 @@ usergroups = ["club", "clubs_council", "finance_council", "slo", "slc", "gad"]
 # All admins and roles {{{
 admins = [
     {"name": "Clubs Council", "mail": "clubs@iiit.ac.in", "role": "clubs_council"},
-    {"name": "Finance Council", "mail": "fc@iiit.ac.in", "role": "finance_council"},
-    {"name": "Student Life Office", "mail": "slo@iiit.ac.in", "role": "slo"},
+    {"name": "Finance Council", "mail": "fc@iiit.ac.in", # Change the Email
+        "role": "finance_council"}, 
+    {"name": "Student Life Office", "mail": "slo.oa@iiit.ac.in", "role": "slc"},
     {"name": "Student Life Committee", "mail": "slc@iiit.ac.in", "role": "slc"},
-    {"name": "GAD", "mail": "gad@iiit.ac.in", "role": "gad"},
+    {"name": "GAD", "mail": "gad@iiit.ac.in", "role": "gad"}, # Change the Email
 ]
 # }}}
 


### PR DESCRIPTION
- Updated SLO Email
- Changed SLO Role to 'SLC'
- No event now goes to 'SLO Pending Event', all directly move to 'SLC Pending Events'.

@v15hv4 Kindly check it once before merging.
Also, change the emails of GAD and Finance Council.